### PR TITLE
Adding support for jsonnet bundler

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,6 +21,8 @@ jobs:
       - name: Install go
         uses: actions/setup-go@v4
       - name: Install Jsonnet
-        run: go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+        run: |
+          go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+          go install -a github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
       - uses: gradle/gradle-build-action@v2
       - run: gradle clean test assemble

--- a/src/main/java/cd/go/plugin/config/yaml/JsonnetConfigParser.java
+++ b/src/main/java/cd/go/plugin/config/yaml/JsonnetConfigParser.java
@@ -11,8 +11,16 @@ import cd.go.plugin.config.yaml.transforms.RootTransform;
  */
 public class JsonnetConfigParser extends YamlConfigParser {
     private static final String VENDOR_TREE_NAME = "vendor";
+    private static final String JSONNET_FILE_NAME = "jsonnetfile.json";
     private String jsonnetCommand;
     private String rootDirectory;
+
+    /**
+     * Create a new JsonnetConfigParser.
+     * @param jsonnetCommand The command to run to execute jsonnet
+     * @param rootDirectory The root directory to resolve relative paths against
+     * @see YamlConfigParser#YamlConfigParser(RootTransform)
+     */
     public JsonnetConfigParser(String jsonnetCommand, String rootDirectory) {
         super(new RootTransform());
         this.jsonnetCommand = jsonnetCommand;
@@ -107,10 +115,14 @@ public class JsonnetConfigParser extends YamlConfigParser {
         }
     }
 
+    /**
+     * Run the jsonnet-bundler to bundle the jsonnet dependencies.
+     */
     private void bundleJsonnet() {
         // Check if <rootDirectory>/jsonnetfile.json exists
-        File jsonnetFile = new File(rootDirectory + File.separator + "jsonnetfile.json");
+        File jsonnetFile = new File(rootDirectory + File.separator + JSONNET_FILE_NAME);
         if (!jsonnetFile.exists()) {
+            // If the jsonnetfile.json doesn't exist, don't run the bundler
             return;
         }
         try {

--- a/src/main/java/cd/go/plugin/config/yaml/JsonnetConfigParser.java
+++ b/src/main/java/cd/go/plugin/config/yaml/JsonnetConfigParser.java
@@ -108,9 +108,9 @@ public class JsonnetConfigParser extends YamlConfigParser {
     }
 
     private void bundleJsonnet() {
-        // Check if the root directory exists
-        File rootDir = new File(rootDirectory);
-        if (!rootDir.exists()) {
+        // Check if <rootDirectory>/jsonnetfile.json exists
+        File jsonnetFile = new File(rootDirectory + File.separator + "jsonnetfile.json");
+        if (!jsonnetFile.exists()) {
             return;
         }
         try {

--- a/src/main/java/cd/go/plugin/config/yaml/JsonnetConfigParser.java
+++ b/src/main/java/cd/go/plugin/config/yaml/JsonnetConfigParser.java
@@ -10,7 +10,7 @@ import cd.go.plugin.config.yaml.transforms.RootTransform;
  * Extends {@link YamlConfigParser} to parse jsonnet files into a JsonConfigCollection.
  */
 public class JsonnetConfigParser extends YamlConfigParser {
-    private static final String VENDOR_NAME = "vendor";
+    private static final String VENDOR_TREE_NAME = "vendor";
     private String jsonnetCommand;
     private String rootDirectory;
     public JsonnetConfigParser(String jsonnetCommand, String rootDirectory) {
@@ -91,7 +91,7 @@ public class JsonnetConfigParser extends YamlConfigParser {
         String[] commandWithArgs = new String[command.length + 3];
         commandWithArgs[0] = jsonnetCommand;
         commandWithArgs[commandWithArgs.length - 2] = "-J";
-        commandWithArgs[commandWithArgs.length - 1] = rootDirectory + File.separator + VENDOR_NAME;
+        commandWithArgs[commandWithArgs.length - 1] = rootDirectory + File.separator + VENDOR_TREE_NAME;
         System.arraycopy(command, 0, commandWithArgs, 1, command.length);
         try {
             ProcessBuilder pb = new ProcessBuilder(commandWithArgs);

--- a/src/main/java/cd/go/plugin/config/yaml/YamlConfigPlugin.java
+++ b/src/main/java/cd/go/plugin/config/yaml/YamlConfigPlugin.java
@@ -141,7 +141,8 @@ public class YamlConfigPlugin implements GoPlugin, ConfigRepoMessages {
             ParsedRequest parsed = ParsedRequest.parse(request);
 
             String jsonnetCommand = getJsonnetCommand();
-            JsonnetConfigParser parser = new JsonnetConfigParser(jsonnetCommand);
+            String rootDirectory = getRootDirectory();
+            JsonnetConfigParser parser = new JsonnetConfigParser(jsonnetCommand, rootDirectory);
             Map<String, String> contents = parsed.getParam("contents");
             JsonConfigCollection result = new JsonConfigCollection();
             contents.forEach((filename, content) -> {
@@ -176,7 +177,8 @@ public class YamlConfigPlugin implements GoPlugin, ConfigRepoMessages {
             String[] files = scanForConfigFiles(parsed, baseDir);
 
             String jsonnetCommand = getJsonnetCommand();
-            JsonnetConfigParser parser = new JsonnetConfigParser(jsonnetCommand);
+            String rootDirectory = getRootDirectory();
+            JsonnetConfigParser parser = new JsonnetConfigParser(jsonnetCommand, rootDirectory);
 
             JsonConfigCollection config = parser.parseFiles(baseDir, files);
             config.updateTargetVersionFromFiles();

--- a/src/test/java/cd/go/plugin/config/yaml/YamlConfigPluginIntegrationTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/YamlConfigPluginIntegrationTest.java
@@ -509,7 +509,7 @@ public class YamlConfigPluginIntegrationTest {
     }
 
     private void assertNoError(JsonObject responseJsonObject) {
-        System.err.println(responseJsonObject.get("errors"));
+        System.out.println(responseJsonObject.get("errors"));
         assertThat(responseJsonObject.get("errors"), Is.<JsonElement>is(new JsonArray()));
     }
 

--- a/src/test/java/cd/go/plugin/config/yaml/YamlConfigPluginIntegrationTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/YamlConfigPluginIntegrationTest.java
@@ -509,7 +509,6 @@ public class YamlConfigPluginIntegrationTest {
     }
 
     private void assertNoError(JsonObject responseJsonObject) {
-        System.out.println(responseJsonObject.get("errors"));
         assertThat(responseJsonObject.get("errors"), Is.<JsonElement>is(new JsonArray()));
     }
 

--- a/src/test/java/cd/go/plugin/config/yaml/YamlConfigPluginIntegrationTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/YamlConfigPluginIntegrationTest.java
@@ -469,7 +469,7 @@ public class YamlConfigPluginIntegrationTest {
     }
 
     @Test
-    public void shouldRespondSuccessWithErrorMessageWhenJsonnetFileIsMissing() throws UnhandledRequestTypeException, IOException {
+    public void shouldRespondSuccessWithRuntimeErrorMessageWhenJsonnetFileIsMissing() throws UnhandledRequestTypeException, IOException {
         File rootDir = setupCase("imported");
         DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest("configrepo", "2.0", REQ_PLUGIN_SETTINGS_CHANGED);
         request.setRequestBody("{\"root_directory\": \"" + rootDir.getAbsolutePath() + "\"}");
@@ -477,7 +477,7 @@ public class YamlConfigPluginIntegrationTest {
 
         GoPluginApiResponse response = parseAndGetResponseForDir(rootDir);
         assertThat(response.responseCode(), is(SUCCESS_RESPONSE_CODE));
-        assertFirstErrorContains(getJsonObjectFromResponse(response), "failed to load jsonnetfile", "imported.gocd.jsonnet");
+        assertFirstErrorContains(getJsonObjectFromResponse(response), "RUNTIME ERROR: couldn't open import", "imported.gocd.jsonnet");
     }
 
     private File setupCase(String caseName) throws IOException {

--- a/src/test/java/cd/go/plugin/config/yaml/YamlConfigPluginIntegrationTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/YamlConfigPluginIntegrationTest.java
@@ -509,6 +509,7 @@ public class YamlConfigPluginIntegrationTest {
     }
 
     private void assertNoError(JsonObject responseJsonObject) {
+        System.err.println(responseJsonObject.get("errors"));
         assertThat(responseJsonObject.get("errors"), Is.<JsonElement>is(new JsonArray()));
     }
 

--- a/src/test/java/cd/go/plugin/config/yaml/YamlConfigPluginIntegrationTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/YamlConfigPluginIntegrationTest.java
@@ -433,6 +433,42 @@ public class YamlConfigPluginIntegrationTest {
     }
 
     @Test
+    public void shouldRespondSuccessToParseDirectoryRequestWhenImportedCaseFile() throws UnhandledRequestTypeException, IOException {
+        File rootDir = setupCase("imported");
+        File jsonnetFile = new File(rootDir, "jsonnetfile.json");
+        FileUtils.copyInputStreamToFile(getResourceAsStream("examples/jsonnetfile.json"), jsonnetFile);
+        DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest("configrepo", "2.0", REQ_PLUGIN_SETTINGS_CHANGED);
+        request.setRequestBody("{\"root_directory\": \"" + rootDir.getAbsolutePath() + "\"}");
+        plugin.handle(request);
+
+        GoPluginApiResponse response = parseAndGetResponseForDir(rootDir);
+        assertThat(response.responseCode(), is(SUCCESS_RESPONSE_CODE));
+        JsonObject responseJsonObject = getJsonObjectFromResponse(response);
+        assertNoError(responseJsonObject);
+
+        JsonObject expected = (JsonObject) readJsonObject("examples.out/imported.gocd.json");
+        assertThat(responseJsonObject, is(new JsonObjectMatcher(expected)));
+    }
+
+    @Test
+    public void shouldRespondSuccessToParseNestedDirectoryRequestWhenImportedCaseFile() throws UnhandledRequestTypeException, IOException {
+        File rootDir = setupCaseNested("imported", "nested");
+        File jsonnetFile = new File(rootDir, "jsonnetfile.json");
+        FileUtils.copyInputStreamToFile(getResourceAsStream("examples/jsonnetfile.json"), jsonnetFile);
+        DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest("configrepo", "2.0", REQ_PLUGIN_SETTINGS_CHANGED);
+        request.setRequestBody("{\"root_directory\": \"" + rootDir.getAbsolutePath() + "\"}");
+        plugin.handle(request);
+
+        GoPluginApiResponse response = parseAndGetResponseForDir(rootDir);
+        assertThat(response.responseCode(), is(SUCCESS_RESPONSE_CODE));
+        JsonObject responseJsonObject = getJsonObjectFromResponse(response);
+        assertNoError(responseJsonObject);
+
+        JsonObject expected = (JsonObject) readJsonObject("examples.out/nested-imported.gocd.json");
+        assertThat(responseJsonObject, is(new JsonObjectMatcher(expected)));
+    }
+
+    @Test
     public void shouldRespondSuccessWithErrorMessageWhenJsonnetFileIsMissing() throws UnhandledRequestTypeException, IOException {
         File rootDir = setupCase("imported");
         DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest("configrepo", "2.0", REQ_PLUGIN_SETTINGS_CHANGED);

--- a/src/test/java/cd/go/plugin/config/yaml/YamlConfigPluginIntegrationTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/YamlConfigPluginIntegrationTest.java
@@ -398,12 +398,65 @@ public class YamlConfigPluginIntegrationTest {
         assertArrayEquals(expectedData, actualData);
     }
 
+    @Test
+    public void shouldCreateVendorDirectory() throws UnhandledRequestTypeException, IOException {
+        File rootDir = setupCase("imported");
+        File jsonnetFile = new File(rootDir, "jsonnetfile.json");
+        FileUtils.copyInputStreamToFile(getResourceAsStream("examples/jsonnetfile.json"), jsonnetFile);
+        DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest("configrepo", "2.0", REQ_PLUGIN_SETTINGS_CHANGED);
+        request.setRequestBody("{\"root_directory\": \"" + rootDir.getAbsolutePath() + "\"}");
+        plugin.handle(request);
+
+        GoPluginApiResponse response = parseAndGetResponseForDir(rootDir);
+        assertThat(response.responseCode(), is(SUCCESS_RESPONSE_CODE));
+        assertNoError(getJsonObjectFromResponse(response));
+
+        File vendorDirectory = new File(rootDir, "vendor");
+        assertTrue(vendorDirectory.exists());
+    }
+
+    @Test
+    public void shouldCreateVendorDirectoryFromOutsideRoot() throws UnhandledRequestTypeException, IOException {
+        File rootDir = setupCaseNested("imported", "nested");
+        File jsonnetFile = new File(rootDir, "jsonnetfile.json");
+        FileUtils.copyInputStreamToFile(getResourceAsStream("examples/jsonnetfile.json"), jsonnetFile);
+        DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest("configrepo", "2.0", REQ_PLUGIN_SETTINGS_CHANGED);
+        request.setRequestBody("{\"root_directory\": \"" + rootDir.getAbsolutePath() + "\"}");
+        plugin.handle(request);
+
+        GoPluginApiResponse response = parseAndGetResponseForDir(rootDir);
+        assertThat(response.responseCode(), is(SUCCESS_RESPONSE_CODE));
+        assertNoError(getJsonObjectFromResponse(response));
+
+        File vendorDirectory = new File(rootDir, "vendor");
+        assertTrue(vendorDirectory.exists());
+    }
+
+    @Test
+    public void shouldRespondSuccessWithErrorMessageWhenJsonnetFileIsMissing() throws UnhandledRequestTypeException, IOException {
+        File rootDir = setupCase("imported");
+        DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest("configrepo", "2.0", REQ_PLUGIN_SETTINGS_CHANGED);
+        request.setRequestBody("{\"root_directory\": \"" + rootDir.getAbsolutePath() + "\"}");
+        plugin.handle(request);
+
+        GoPluginApiResponse response = parseAndGetResponseForDir(rootDir);
+        assertThat(response.responseCode(), is(SUCCESS_RESPONSE_CODE));
+        assertFirstErrorContains(getJsonObjectFromResponse(response), "failed to load jsonnetfile", "imported.gocd.jsonnet");
+    }
+
     private File setupCase(String caseName) throws IOException {
         return setupCase(caseName, "gocd.jsonnet");
     }
 
     private File setupCase(String caseName, String extension) throws IOException {
         File simpleFile = Files.createFile(tempDir.resolve(caseName + "." + extension)).toFile();
+        FileUtils.copyInputStreamToFile(getResourceAsStream("examples/" + caseName + ".gocd.jsonnet"), simpleFile);
+        return tempDir.toFile();
+    }
+
+    private File setupCaseNested(String caseName, String nestedDir) throws IOException {
+        File nestedDirFile = Files.createDirectory(tempDir.resolve(nestedDir)).toFile();
+        File simpleFile = Files.createFile(nestedDirFile.toPath().resolve(caseName + ".gocd.jsonnet")).toFile();
         FileUtils.copyInputStreamToFile(getResourceAsStream("examples/" + caseName + ".gocd.jsonnet"), simpleFile);
         return tempDir.toFile();
     }

--- a/src/test/resources/examples.out/imported.gocd.json
+++ b/src/test/resources/examples.out/imported.gocd.json
@@ -1,0 +1,36 @@
+{
+    "target_version": 1,
+    "errors": [],
+    "environments": [],
+    "pipelines": [
+      {
+        "location": "imported.gocd.jsonnet",
+        "name": "pipe1",
+        "group": "simple",
+        "materials": [
+          {
+            "name": "mygit",
+            "type": "git",
+            "url": "http://my.example.org/mygit.git"
+          }
+        ],
+        "stages": [
+          {
+            "name": "build",
+            "jobs": [
+              {
+                "name": "build",
+                "tasks": [
+                  {
+                    "type": "exec",
+                    "command": "make"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+  

--- a/src/test/resources/examples.out/nested-imported.gocd.json
+++ b/src/test/resources/examples.out/nested-imported.gocd.json
@@ -1,0 +1,36 @@
+{
+    "target_version": 1,
+    "errors": [],
+    "environments": [],
+    "pipelines": [
+      {
+        "location": "nested/imported.gocd.jsonnet",
+        "name": "pipe1",
+        "group": "simple",
+        "materials": [
+          {
+            "name": "mygit",
+            "type": "git",
+            "url": "http://my.example.org/mygit.git"
+          }
+        ],
+        "stages": [
+          {
+            "name": "build",
+            "jobs": [
+              {
+                "name": "build",
+                "tasks": [
+                  {
+                    "type": "exec",
+                    "command": "make"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+  

--- a/src/test/resources/examples/imported.gocd.jsonnet
+++ b/src/test/resources/examples/imported.gocd.jsonnet
@@ -1,0 +1,30 @@
+local tasks = import "github.com/getsentry/gocd-jsonnet/v1.0.0/gocd-tasks.libsonnet";
+{
+  "pipelines": {
+    "pipe1": {
+      "group": "simple" + tasks.script("test"),
+      "materials": {
+        "mygit": {
+          "git": "http://my.example.org/mygit.git"
+        }
+      },
+      "stages": [
+        {
+          "build": {
+            "jobs": {
+              "build": {
+                "tasks": [
+                  {
+                    "exec": {
+                      "command": "make"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+}

--- a/src/test/resources/examples/imported.gocd.jsonnet
+++ b/src/test/resources/examples/imported.gocd.jsonnet
@@ -1,8 +1,8 @@
-local tasks = import "github.com/getsentry/gocd-jsonnet/v1.0.0/gocd-tasks.libsonnet";
+local utils = import "github.com/getsentry/test-jsonnet/libs/utils.libsonnet";
 {
   "pipelines": {
     "pipe1": {
-      "group": "simple" + tasks.script("test"),
+      "group": utils.identity("simple"),
       "materials": {
         "mygit": {
           "git": "http://my.example.org/mygit.git"

--- a/src/test/resources/examples/jsonnetfile.json
+++ b/src/test/resources/examples/jsonnetfile.json
@@ -4,11 +4,11 @@
     {
       "source": {
         "git": {
-          "remote": "https://github.com/getsentry/gocd-jsonnet.git",
-          "subdir": "v1.0.0"
+          "remote": "https://github.com/getsentry/test-jsonnet.git",
+          "subdir": "libs"
         }
       },
-      "version": "main"
+      "version": "v1.0.0"
     }
   ],
   "legacyImports": true

--- a/src/test/resources/examples/jsonnetfile.json
+++ b/src/test/resources/examples/jsonnetfile.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/getsentry/gocd-jsonnet.git",
+          "subdir": "v1.0.0"
+        }
+      },
+      "version": "main"
+    }
+  ],
+  "legacyImports": true
+}


### PR DESCRIPTION
In order for this plugin to actually be useful, we need the ability to use the [jsonnet-bundler](https://github.com/jsonnet-bundler/jsonnet-bundler) so we can import external dependencies into our jsonnet files.

Some noteworthy changes: 
* Before compiling the jsonnet, the code first tries to install dependencies using the `jsonnetfile.json` inside the provided `rootDirectory` (if it exists).
* The additional flag `-J vendor` is needed when compiling jsonnet so that we include the vendor tree.
* There is a new set of tests aimed at testing the new bundler functionality, if you have any ideas for more/better tests, let me know!