### PR TITLE
Removing root directory setting

### DIFF
--- a/src/main/java/cd/go/plugin/config/yaml/PluginSettings.java
+++ b/src/main/java/cd/go/plugin/config/yaml/PluginSettings.java
@@ -4,22 +4,18 @@ import java.util.Map;
 
 class PluginSettings {
     static final String PLUGIN_SETTINGS_FILE_PATTERN = "file_pattern";
-    static final String PLUGIN_SETTINGS_ROOT_DIRECTORY = "root_directory";
     static final String PLUGIN_SETTINGS_JSONNET_COMMAND = "jsonnet_command";
     static final String DEFAULT_FILE_PATTERN = "**/*.gocd.jsonnet";
-    static final String DEFAULT_ROOT_DIRECTORY = "./gocd/templates";
     static final String DEFAULT_JSONNET_COMMAND = "jsonnet";
 
     private String filePattern;
-    private String rootDirectory;
     private String jsonnetCommand;
 
     PluginSettings() {
     }
 
-    PluginSettings(String filePattern, String rootDirectory, String jsonnetCommand) {
+    PluginSettings(String filePattern, String jsonnetCommand) {
         this.filePattern = filePattern;
-        this.rootDirectory = rootDirectory;
         this.jsonnetCommand = jsonnetCommand;
     }
 
@@ -27,17 +23,12 @@ class PluginSettings {
         Map<String, String> raw = JSONUtils.fromJSON(json);
         return new PluginSettings(
             raw.get(PLUGIN_SETTINGS_FILE_PATTERN),
-            raw.get(PLUGIN_SETTINGS_ROOT_DIRECTORY),
             raw.get(PLUGIN_SETTINGS_JSONNET_COMMAND)
         );
     }
 
     String getFilePattern() {
         return filePattern;
-    }
-
-    String getRootDirectory() {
-        return rootDirectory;
     }
 
     String getJsonnetCommand() {

--- a/src/main/java/cd/go/plugin/config/yaml/YamlConfigPlugin.java
+++ b/src/main/java/cd/go/plugin/config/yaml/YamlConfigPlugin.java
@@ -24,8 +24,6 @@ import java.util.function.Supplier;
 
 import static cd.go.plugin.config.yaml.PluginSettings.DEFAULT_FILE_PATTERN;
 import static cd.go.plugin.config.yaml.PluginSettings.PLUGIN_SETTINGS_FILE_PATTERN;
-import static cd.go.plugin.config.yaml.PluginSettings.DEFAULT_ROOT_DIRECTORY;
-import static cd.go.plugin.config.yaml.PluginSettings.PLUGIN_SETTINGS_ROOT_DIRECTORY;
 import static cd.go.plugin.config.yaml.PluginSettings.DEFAULT_JSONNET_COMMAND;
 import static cd.go.plugin.config.yaml.PluginSettings.PLUGIN_SETTINGS_JSONNET_COMMAND;
 import static com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse.*;
@@ -34,7 +32,6 @@ import static java.lang.String.format;
 @Extension
 public class YamlConfigPlugin implements GoPlugin, ConfigRepoMessages {
     private static final String DISPLAY_NAME_FILE_PATTERN = "Go Jsonnet files pattern";
-    private static final String DISPLAY_NAME_ROOT_DIRECTORY = "Jsonnet root directory";
     private static final String DISPLAY_NAME_JSONNET_COMMAND = "Jsonnet command";
     private static final String PLUGIN_ID = "jsonnet.config.plugin";
     private static Logger LOGGER = Logger.getLoggerFor(YamlConfigPlugin.class);
@@ -113,13 +110,6 @@ public class YamlConfigPlugin implements GoPlugin, ConfigRepoMessages {
         return DEFAULT_FILE_PATTERN;
     }
 
-    String getRootDirectory() {
-        if (null != settings && !isBlank(settings.getRootDirectory())) {
-            return settings.getRootDirectory();
-        }
-        return DEFAULT_ROOT_DIRECTORY;
-    }
-
     String getJsonnetCommand() {
         if (null != settings && !isBlank(settings.getJsonnetCommand())) {
             return settings.getJsonnetCommand();
@@ -141,8 +131,7 @@ public class YamlConfigPlugin implements GoPlugin, ConfigRepoMessages {
             ParsedRequest parsed = ParsedRequest.parse(request);
 
             String jsonnetCommand = getJsonnetCommand();
-            String rootDirectory = getRootDirectory();
-            JsonnetConfigParser parser = new JsonnetConfigParser(jsonnetCommand, rootDirectory);
+            JsonnetConfigParser parser = new JsonnetConfigParser(jsonnetCommand);
             Map<String, String> contents = parsed.getParam("contents");
             JsonConfigCollection result = new JsonConfigCollection();
             contents.forEach((filename, content) -> {
@@ -177,8 +166,7 @@ public class YamlConfigPlugin implements GoPlugin, ConfigRepoMessages {
             String[] files = scanForConfigFiles(parsed, baseDir);
 
             String jsonnetCommand = getJsonnetCommand();
-            String rootDirectory = getRootDirectory();
-            JsonnetConfigParser parser = new JsonnetConfigParser(jsonnetCommand, rootDirectory);
+            JsonnetConfigParser parser = new JsonnetConfigParser(jsonnetCommand);
 
             JsonConfigCollection config = parser.parseFiles(baseDir, files);
             config.updateTargetVersionFromFiles();
@@ -227,8 +215,7 @@ public class YamlConfigPlugin implements GoPlugin, ConfigRepoMessages {
     private GoPluginApiResponse handleGetPluginSettingsConfiguration() {
         Map<String, Object> response = new HashMap<>();
         response.put(PLUGIN_SETTINGS_FILE_PATTERN, createField(DISPLAY_NAME_FILE_PATTERN, DEFAULT_FILE_PATTERN, false, false, "0"));
-        response.put(PLUGIN_SETTINGS_ROOT_DIRECTORY, createField(DISPLAY_NAME_ROOT_DIRECTORY, DEFAULT_ROOT_DIRECTORY, false, false, "1"));
-        response.put(PLUGIN_SETTINGS_JSONNET_COMMAND, createField(DISPLAY_NAME_JSONNET_COMMAND, DEFAULT_JSONNET_COMMAND, false, false, "2"));
+        response.put(PLUGIN_SETTINGS_JSONNET_COMMAND, createField(DISPLAY_NAME_JSONNET_COMMAND, DEFAULT_JSONNET_COMMAND, false, false, "1"));
         return success(gson.toJson(response));
     }
 

--- a/src/main/resources/plugin-settings.template.html
+++ b/src/main/resources/plugin-settings.template.html
@@ -2,9 +2,6 @@
     <label>GoCD Jsonnet files global pattern:</label>
     <input type="text" ng-model="file_pattern" ng-required="false" placeholder="**/*.gocd.jsonnet" />
     <span class="form_error" ng-show="GOINPUTNAME[file_pattern].$error.server">{{ GOINPUTNAME[file_pattern].$error.server }}</span>
-    <label>GoCD root directory:</label>
-    <input type="text" ng-model="root_directory" ng-required="false" placeholder="./gocd/templates" />
-    <span class="form_error" ng-show="GOINPUTNAME[root_directory].$error.server">{{ GOINPUTNAME[root_directory].$error.server }}</span>
     <label>Jsonnet command:</label>
     <input type="text" ng-model="jsonnet_command" ng-required="false" placeholder="jsonnet" />
     <span class="form_error" ng-show="GOINPUTNAME[jsonnet_command].$error.server">{{ GOINPUTNAME[jsonnet_command].$error.server }}</span>

--- a/src/test/java/cd/go/plugin/config/yaml/PluginSettingsTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/PluginSettingsTest.java
@@ -9,55 +9,23 @@ import static org.hamcrest.core.IsEqual.equalTo;
 public class PluginSettingsTest {
     @Test
     public void shouldGetFilePattern() {
-        PluginSettings pluginSettings = new PluginSettings("file-pattern", null, null);
+        PluginSettings pluginSettings = new PluginSettings("file-pattern", null);
 
         assertThat(pluginSettings.getFilePattern(), is(equalTo("file-pattern")));
-    }
-
-    @Test
-    public void shouldGetRootDirectory() {
-        PluginSettings pluginSettings = new PluginSettings(null, "root-directory", null);
-
-        assertThat(pluginSettings.getRootDirectory(), is(equalTo("root-directory")));
     }
 
     @Test
     public void shouldGetJsonnetCommand() {
-        PluginSettings pluginSettings = new PluginSettings(null, null, "jsonnet-command");
+        PluginSettings pluginSettings = new PluginSettings(null, "jsonnet-command");
 
         assertThat(pluginSettings.getJsonnetCommand(), is(equalTo("jsonnet-command")));
-    }
-
-    @Test
-    public void shouldGetFilePatternAndRootDirectory() {
-        PluginSettings pluginSettings = new PluginSettings("file-pattern", "root-directory", null);
-
-        assertThat(pluginSettings.getFilePattern(), is(equalTo("file-pattern")));
-        assertThat(pluginSettings.getRootDirectory(), is(equalTo("root-directory")));
     }
 
     @Test
     public void shouldGetFilePatternAndJsonnetCommand() {
-        PluginSettings pluginSettings = new PluginSettings("file-pattern", null, "jsonnet-command");
+        PluginSettings pluginSettings = new PluginSettings("file-pattern", "jsonnet-command");
 
         assertThat(pluginSettings.getFilePattern(), is(equalTo("file-pattern")));
-        assertThat(pluginSettings.getJsonnetCommand(), is(equalTo("jsonnet-command")));
-    }
-
-    @Test
-    public void shouldGetRootDirectoryAndJsonnetCommand() {
-        PluginSettings pluginSettings = new PluginSettings(null, "root-directory", "jsonnet-command");
-
-        assertThat(pluginSettings.getRootDirectory(), is(equalTo("root-directory")));
-        assertThat(pluginSettings.getJsonnetCommand(), is(equalTo("jsonnet-command")));
-    }
-
-    @Test
-    public void shouldGetFilePatternAndRootDirectoryAndJsonnetCommand() {
-        PluginSettings pluginSettings = new PluginSettings("file-pattern", "root-directory", "jsonnet-command");
-
-        assertThat(pluginSettings.getFilePattern(), is(equalTo("file-pattern")));
-        assertThat(pluginSettings.getRootDirectory(), is(equalTo("root-directory")));
         assertThat(pluginSettings.getJsonnetCommand(), is(equalTo("jsonnet-command")));
     }
 }

--- a/src/test/java/cd/go/plugin/config/yaml/YamlConfigPluginIntegrationTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/YamlConfigPluginIntegrationTest.java
@@ -403,9 +403,6 @@ public class YamlConfigPluginIntegrationTest {
         File rootDir = setupCase("imported");
         File jsonnetFile = new File(rootDir, "jsonnetfile.json");
         FileUtils.copyInputStreamToFile(getResourceAsStream("examples/jsonnetfile.json"), jsonnetFile);
-        DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest("configrepo", "2.0", REQ_PLUGIN_SETTINGS_CHANGED);
-        request.setRequestBody("{\"root_directory\": \"" + rootDir.getAbsolutePath() + "\"}");
-        plugin.handle(request);
 
         GoPluginApiResponse response = parseAndGetResponseForDir(rootDir);
         assertThat(response.responseCode(), is(SUCCESS_RESPONSE_CODE));
@@ -420,9 +417,6 @@ public class YamlConfigPluginIntegrationTest {
         File rootDir = setupCaseNested("imported", "nested");
         File jsonnetFile = new File(rootDir, "jsonnetfile.json");
         FileUtils.copyInputStreamToFile(getResourceAsStream("examples/jsonnetfile.json"), jsonnetFile);
-        DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest("configrepo", "2.0", REQ_PLUGIN_SETTINGS_CHANGED);
-        request.setRequestBody("{\"root_directory\": \"" + rootDir.getAbsolutePath() + "\"}");
-        plugin.handle(request);
 
         GoPluginApiResponse response = parseAndGetResponseForDir(rootDir);
         assertThat(response.responseCode(), is(SUCCESS_RESPONSE_CODE));
@@ -437,9 +431,6 @@ public class YamlConfigPluginIntegrationTest {
         File rootDir = setupCase("imported");
         File jsonnetFile = new File(rootDir, "jsonnetfile.json");
         FileUtils.copyInputStreamToFile(getResourceAsStream("examples/jsonnetfile.json"), jsonnetFile);
-        DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest("configrepo", "2.0", REQ_PLUGIN_SETTINGS_CHANGED);
-        request.setRequestBody("{\"root_directory\": \"" + rootDir.getAbsolutePath() + "\"}");
-        plugin.handle(request);
 
         GoPluginApiResponse response = parseAndGetResponseForDir(rootDir);
         assertThat(response.responseCode(), is(SUCCESS_RESPONSE_CODE));
@@ -455,9 +446,6 @@ public class YamlConfigPluginIntegrationTest {
         File rootDir = setupCaseNested("imported", "nested");
         File jsonnetFile = new File(rootDir, "jsonnetfile.json");
         FileUtils.copyInputStreamToFile(getResourceAsStream("examples/jsonnetfile.json"), jsonnetFile);
-        DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest("configrepo", "2.0", REQ_PLUGIN_SETTINGS_CHANGED);
-        request.setRequestBody("{\"root_directory\": \"" + rootDir.getAbsolutePath() + "\"}");
-        plugin.handle(request);
 
         GoPluginApiResponse response = parseAndGetResponseForDir(rootDir);
         assertThat(response.responseCode(), is(SUCCESS_RESPONSE_CODE));
@@ -471,9 +459,6 @@ public class YamlConfigPluginIntegrationTest {
     @Test
     public void shouldRespondSuccessWithRuntimeErrorMessageWhenJsonnetFileIsMissing() throws UnhandledRequestTypeException, IOException {
         File rootDir = setupCase("imported");
-        DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest("configrepo", "2.0", REQ_PLUGIN_SETTINGS_CHANGED);
-        request.setRequestBody("{\"root_directory\": \"" + rootDir.getAbsolutePath() + "\"}");
-        plugin.handle(request);
 
         GoPluginApiResponse response = parseAndGetResponseForDir(rootDir);
         assertThat(response.responseCode(), is(SUCCESS_RESPONSE_CODE));


### PR DESCRIPTION
Removing the root directory setting and opting instead to look for and dynamically find/bundle directories if they contain a jsonnetfile.json. This means that if you want to use external dependencies in a given jsonnet file, the directory that contains that file must contain a jsonnetfile.json. This allows more fine-tuned dependency management, but at the cost of having potentially duplicate jsonnetfile.json's in nested directories.
