### PR TITLE
Enabling multiple pipelines in one jsonnet file

### DIFF
--- a/src/main/java/cd/go/plugin/config/yaml/JsonnetConfigParser.java
+++ b/src/main/java/cd/go/plugin/config/yaml/JsonnetConfigParser.java
@@ -75,6 +75,10 @@ public class JsonnetConfigParser extends YamlConfigParser {
      */
     @Override
     public void parseStream(JsonConfigCollection result, InputStream input, String location) {
+        if (location.endsWith(".yaml") || location.endsWith(".yml")) {
+            super.parseStream(result, input, location);
+            return;
+        }
         try {
             InputStream jsonInputStream = compileJsonnet(input);
             super.parseStream(result, jsonInputStream, location);

--- a/src/main/java/cd/go/plugin/config/yaml/YamlConfigParser.java
+++ b/src/main/java/cd/go/plugin/config/yaml/YamlConfigParser.java
@@ -3,8 +3,10 @@ package cd.go.plugin.config.yaml;
 import cd.go.plugin.config.yaml.transforms.RootTransform;
 import com.esotericsoftware.yamlbeans.YamlConfig;
 import com.esotericsoftware.yamlbeans.YamlReader;
+import com.google.gson.Gson;
 
 import java.io.*;
+import java.util.Map;
 
 public class YamlConfigParser {
     private RootTransform rootTransform;
@@ -42,6 +44,19 @@ public class YamlConfigParser {
             config.setAllowDuplicates(false);
             YamlReader reader = new YamlReader(contentReader, config);
             Object rootObject = reader.read();
+            Map<String, Object> rootMap = (Map<String, Object>) rootObject;
+            boolean isNested = false;
+            for (Map.Entry<String, Object> pe : rootMap.entrySet()) {
+                if (pe.getKey().endsWith(".yaml")) {
+                    Gson gson = new Gson();
+                    String json = gson.toJson(pe.getValue());
+                    parseStream(result, new ByteArrayInputStream(json.getBytes()), pe.getKey());
+                    isNested = true;
+                }
+            }
+            if (isNested) {
+                return;
+            }
             JsonConfigCollection filePart = rootTransform.transform(rootObject, location);
             result.append(filePart);
         } catch (YamlReader.YamlReaderException e) {

--- a/src/test/java/cd/go/plugin/config/yaml/YamlConfigPluginIntegrationTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/YamlConfigPluginIntegrationTest.java
@@ -439,6 +439,19 @@ public class YamlConfigPluginIntegrationTest {
         assertFirstErrorContains(getJsonObjectFromResponse(response), "RUNTIME ERROR: couldn't open import", "imported.gocd.jsonnet");
     }
 
+    @Test
+    public void shouldHandleMultiplePipelinesInOneFile() throws UnhandledRequestTypeException, IOException {
+        File rootDir = setupCase("multiple-pipelines");
+
+        GoPluginApiResponse response = parseAndGetResponseForDir(rootDir);
+        assertThat(response.responseCode(), is(SUCCESS_RESPONSE_CODE));
+        JsonObject responseJsonObject = getJsonObjectFromResponse(response);
+        assertNoError(responseJsonObject);
+
+        JsonObject expected = (JsonObject) readJsonObject("examples.out/multiple-pipelines.gocd.json");
+        assertThat(responseJsonObject, is(new JsonObjectMatcher(expected)));
+    }
+
     private File setupCase(String caseName) throws IOException {
         return setupCase(caseName, "gocd.jsonnet");
     }

--- a/src/test/resources/examples.out/multiple-pipelines.gocd.json
+++ b/src/test/resources/examples.out/multiple-pipelines.gocd.json
@@ -1,0 +1,64 @@
+{
+    "target_version": 1,
+    "errors": [],
+    "environments": [],
+    "pipelines": [
+      {
+        "location": "simple-1.yaml",
+        "name": "pipe1",
+        "group": "simple-1",
+        "materials": [
+          {
+            "name": "mygit",
+            "type": "git",
+            "url": "http://my.example.org/mygit.git"
+          }
+        ],
+        "stages": [
+          {
+            "name": "build",
+            "jobs": [
+              {
+                "name": "build",
+                "tasks": [
+                  {
+                    "type": "exec",
+                    "command": "make"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "location": "simple-2.yaml",
+        "name": "pipe1",
+        "group": "simple-2",
+        "materials": [
+          {
+            "name": "mygit",
+            "type": "git",
+            "url": "http://my.example.org/mygit.git"
+          }
+        ],
+        "stages": [
+          {
+            "name": "build",
+            "jobs": [
+              {
+                "name": "build",
+                "tasks": [
+                  {
+                    "type": "exec",
+                    "command": "make"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+  

--- a/src/test/resources/examples/multiple-pipelines.gocd.jsonnet
+++ b/src/test/resources/examples/multiple-pipelines.gocd.jsonnet
@@ -1,0 +1,61 @@
+{
+  'simple-1.yaml': {
+    pipelines: {
+      pipe1: {
+        group: 'simple-1',
+        materials: {
+          mygit: {
+            git: 'http://my.example.org/mygit.git',
+          },
+        },
+        stages: [
+          {
+            build: {
+              jobs: {
+                build: {
+                  tasks: [
+                    {
+                      exec: {
+                        command: 'make',
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      },
+    },
+  },
+  'simple-2.yaml': {
+    pipelines: {
+      pipe1: {
+        group: 'simple-2',
+        materials: {
+          mygit: {
+            git: 'http://my.example.org/mygit.git',
+          },
+        },
+        stages: [
+          {
+            build: {
+              jobs: {
+                build: {
+                  tasks: [
+                    {
+                      exec: {
+                        command: 'make',
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      },
+    },
+  },
+
+}


### PR DESCRIPTION
Currently, the plugin can only handle a single pipeline at a time. This PR enables having multiple pipelines configured in a single jsonnet file.
