### PR TITLE
Improving the logic that handles multiple pipelines

### DIFF
--- a/src/main/java/cd/go/plugin/config/yaml/YamlConfigParser.java
+++ b/src/main/java/cd/go/plugin/config/yaml/YamlConfigParser.java
@@ -3,10 +3,8 @@ package cd.go.plugin.config.yaml;
 import cd.go.plugin.config.yaml.transforms.RootTransform;
 import com.esotericsoftware.yamlbeans.YamlConfig;
 import com.esotericsoftware.yamlbeans.YamlReader;
-import com.google.gson.Gson;
 
 import java.io.*;
-import java.util.Map;
 
 public class YamlConfigParser {
     private RootTransform rootTransform;
@@ -44,19 +42,6 @@ public class YamlConfigParser {
             config.setAllowDuplicates(false);
             YamlReader reader = new YamlReader(contentReader, config);
             Object rootObject = reader.read();
-            Map<String, Object> rootMap = (Map<String, Object>) rootObject;
-            boolean isNested = false;
-            for (Map.Entry<String, Object> pe : rootMap.entrySet()) {
-                if (pe.getKey().endsWith(".yaml")) {
-                    Gson gson = new Gson();
-                    String json = gson.toJson(pe.getValue());
-                    parseStream(result, new ByteArrayInputStream(json.getBytes()), pe.getKey());
-                    isNested = true;
-                }
-            }
-            if (isNested) {
-                return;
-            }
             JsonConfigCollection filePart = rootTransform.transform(rootObject, location);
             result.append(filePart);
         } catch (YamlReader.YamlReaderException e) {


### PR DESCRIPTION
Moving the logic that handles nested pipelines from the `YamlConfigParser` to the `JsonnetConfigParser`.