### PR TITLE
Removing nested yaml parsing functionality

### DIFF
--- a/src/main/java/cd/go/plugin/config/yaml/YamlConfigParser.java
+++ b/src/main/java/cd/go/plugin/config/yaml/YamlConfigParser.java
@@ -3,13 +3,10 @@ package cd.go.plugin.config.yaml;
 import cd.go.plugin.config.yaml.transforms.RootTransform;
 import com.esotericsoftware.yamlbeans.YamlConfig;
 import com.esotericsoftware.yamlbeans.YamlReader;
-import com.google.gson.Gson;
 
 import java.io.*;
-import java.util.Map;
 
 public class YamlConfigParser {
-    private static final Gson gson = new Gson();
     private RootTransform rootTransform;
 
     public YamlConfigParser() {
@@ -45,18 +42,6 @@ public class YamlConfigParser {
             config.setAllowDuplicates(false);
             YamlReader reader = new YamlReader(contentReader, config);
             Object rootObject = reader.read();
-            Map<String, Object> rootMap = (Map<String, Object>) rootObject;
-            boolean isNested = false;
-            for (Map.Entry<String, Object> pe : rootMap.entrySet()) {
-                if (pe.getKey().endsWith(".yaml")) {
-                    String json = gson.toJson(pe.getValue());
-                    parseStream(result, new ByteArrayInputStream(json.getBytes()), pe.getKey());
-                    isNested = true;
-                }
-            }
-            if (isNested) {
-                return;
-            }
             JsonConfigCollection filePart = rootTransform.transform(rootObject, location);
             result.append(filePart);
         } catch (YamlReader.YamlReaderException e) {

--- a/src/test/java/cd/go/plugin/config/yaml/YamlConfigPluginIntegrationTest.java
+++ b/src/test/java/cd/go/plugin/config/yaml/YamlConfigPluginIntegrationTest.java
@@ -516,12 +516,9 @@ public class YamlConfigPluginIntegrationTest {
         File rootDir = setupCase("multiple-pipelines");
 
         GoPluginApiResponse response = parseAndGetResponseForDir(rootDir);
-        assertThat(response.responseCode(), is(SUCCESS_RESPONSE_CODE));
+        assertThat(response.responseCode(), is(DefaultGoPluginApiResponse.INTERNAL_ERROR));
         JsonObject responseJsonObject = getJsonObjectFromResponse(response);
-        assertNoError(responseJsonObject);
-
-        JsonObject expected = (JsonObject) readJsonObject("examples.out/multiple-pipelines.gocd.json");
-        assertThat(responseJsonObject, is(new JsonObjectMatcher(expected)));
+        assertFirstError(responseJsonObject, "cd.go.plugin.config.yaml.YamlConfigException: simple-1.yaml is invalid, expected format_version, pipelines, environments, or common", "Jsonnet config plugin");
     }
 
     private File setupCaseYaml(String caseName) throws IOException {


### PR DESCRIPTION
In order to keep the scope of the plugins functionality limited, we opted not to include functionality for parsing nested yaml files. Instead, pipelines should be combined into a single configuration.